### PR TITLE
Add failing test for directive returning when the return is implicit.

### DIFF
--- a/babel-ng-annotate.js
+++ b/babel-ng-annotate.js
@@ -106,6 +106,12 @@ module.exports = function() {
       ArrowFunctionExpression: {
         enter(path) {
           ngInject.inspectFunction(path, ctx);
+        },
+        exit(path, state) {
+          if(!state.opts.explicitOnly){
+            let targets = matchDirectiveReturnObject(path);
+            addTargets(targets);
+          }
         }
       },
       FunctionDeclaration: {

--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -73,9 +73,9 @@ function matchDirectiveReturnObject(path) {
     // only matches inside directives
     // return { .. controller: function($scope, $timeout), ...}
 
-    return limit("directive", t.isReturnStatement(node) &&
-        node.argument && t.isObjectExpression(node.argument) &&
-        matchProp("controller", (path.get && path.get("argument.properties") || node.argument.properties)));
+    return limit("directive",
+        (t.isReturnStatement(node) && node.argument && t.isObjectExpression(node.argument) && matchProp("controller", (path.get && path.get("argument.properties") || node.argument.properties))) ||
+        (t.isArrowFunctionExpression(node) && node.body && t.isObjectExpression(node.body) && matchProp("controller", (path.get && path.get("body.properties") || node.body.properties))));
 }
 
 function limit(name, path) {

--- a/tests/simple-arrow.js
+++ b/tests/simple-arrow.js
@@ -252,6 +252,11 @@ module.exports = {
               }
           }
       });
+      myMod.directive("foo", ($scope) => ({
+          controller: ($scope, $timeout) => {
+              bar;
+          }
+      }));
     },
     expected: function(){
       // directive return object
@@ -269,6 +274,11 @@ module.exports = {
               }
           }
       }]);
+      myMod.directive("foo", ["$scope", ($scope) => ({
+          controller: ["$scope", "$timeout", ($scope, $timeout) => {
+              bar;
+          }]
+      })]);
     }
   },
   {


### PR DESCRIPTION
```xml
    <testcase name="#171 ES2015: Directive return object (arrow function)">
      <failure>
          ---
            operator: equal
            expected: '// directive return objectmyMod.directive("foo", ["$scope", $scope =&gt; {    return {        controller: ["$scope", "$timeout", ($scope, $timeout) =&gt; {            bar;        }]    };}]);myMod.directive("foo", ["$scope", $scope =&gt; {    return {        controller: () =&gt; {            bar;        }    };}]);myMod.directive("foo", ["$scope", $scope =&gt; ({    controller: ["$scope", "$timeout", ($scope, $timeout) =&gt; {        bar;    }]})]);'
            actual: '// directive return objectmyMod.directive("foo", ["$scope", $scope =&gt; {    return {        controller: ["$scope", "$timeout", ($scope, $timeout) =&gt; {            bar;        }]    };}]);myMod.directive("foo", ["$scope", $scope =&gt; {    return {        controller: () =&gt; {            bar;        }    };}]);myMod.directive("foo", ["$scope", $scope =&gt; ({    controller: ($scope, $timeout) =&gt; {        bar;    }})]);'
            at: doTransform (/home/kai/src/babel-plugin-angularjs-annotate/tests/tests.js:84:5)
          ...
      </failure>
    </testcase>
```
