### PR TITLE
Avoid error when state.children is a function call (CallExpression)

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -218,11 +218,15 @@ function matchNgUi(path) {
         matchStateProps(properties, res);
 
         const childrenArrayExpression = matchProp("children", properties);
-        const children = childrenArrayExpression && childrenArrayExpression.get("elements");
+        if (!childrenArrayExpression || !t.isArrayExpression(childrenArrayExpression)) {
+            return
+        }
 
+        const children = childrenArrayExpression.get("elements");
         if (!children) {
             return;
         }
+
         children.forEach(recursiveMatch);
     }
 


### PR DESCRIPTION
I encountered an error when the value of a  `children` property was a function call, not an array.

Specific example:

```
children: angular.copy(initialStateObjectThatIsReused)
```

I'm not experienced with Babel enough to explain why this happens - getting `elements` seems reliable enough to me. But, adding an explicit check that `children` is an array makes the problem go away.