### PR TITLE
Directive definition in a variable

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -73,9 +73,30 @@ function matchDirectiveReturnObject(path) {
     // only matches inside directives
     // return { .. controller: function($scope, $timeout), ...}
 
-    return limit("directive",
-        (t.isReturnStatement(node) && node.argument && t.isObjectExpression(node.argument) && matchProp("controller", (path.get && path.get("argument.properties") || node.argument.properties))) ||
-        (t.isArrowFunctionExpression(node) && node.body && t.isObjectExpression(node.body) && matchProp("controller", (path.get && path.get("body.properties") || node.body.properties))));
+    var returnPath;
+    if (t.isReturnStatement(node) && node.argument) {
+        if (t.isObjectExpression(node.argument)) {
+            returnPath = matchProp("controller", (path.get && path.get("argument.properties") || node.argument.properties));
+        } else if (path.get && t.isIdentifier(path.get("argument"))) {
+            var binding = path.scope.getBinding(node.argument.name);
+            var bound = binding && binding.path;
+            if (bound && t.isVariableDeclarator(bound)) {
+                var init = bound.get("init");
+                if (init && t.isObjectExpression(init)) {
+                    returnPath = matchProp("controller", init.get("properties"));
+                }
+            }
+        }
+    }
+    if (!returnPath) {
+        returnPath =
+            t.isArrowFunctionExpression(node)
+            && node.body
+            && t.isObjectExpression(node.body)
+            && matchProp("controller", (path.get && path.get("body.properties") || node.body.properties));
+    }
+
+    return limit("directive", returnPath);
 }
 
 function limit(name, path) {

--- a/tests/references.js
+++ b/tests/references.js
@@ -209,6 +209,39 @@ module.exports = {
             angular.module("test.feedback.pkg", [])
                 .component("testFeedback", testFeedback);
         }
+    },
+    {
+        name: "directive definition as a variable",
+        implicit: true,
+        input: function () {
+            function testDirective() {
+                var directiveDefinition = {
+                    controller: testFeedbackController
+                };
+
+                return directiveDefinition;
+
+                function testFeedbackController(foo) {
+                }
+            }
+
+            angular.module('MyMod').directive('testDirective', testDirective);
+        },
+        expected: function () {
+            function testDirective() {
+                testFeedbackController.$inject = ['foo'];
+                var directiveDefinition = {
+                    controller: testFeedbackController
+                };
+
+                return directiveDefinition;
+
+                function testFeedbackController(foo) {
+                }
+            }
+
+            angular.module('MyMod').directive('testDirective', testDirective);
+        }
     }
   ]
 }

--- a/tests/references.js
+++ b/tests/references.js
@@ -225,11 +225,11 @@ module.exports = {
                 }
             }
 
-            angular.module('MyMod').directive('testDirective', testDirective);
+            angular.module("MyMod").directive("testDirective", testDirective);
         },
         expected: function () {
             function testDirective() {
-                testFeedbackController.$inject = ['foo'];
+                testFeedbackController.$inject = ["foo"];
                 var directiveDefinition = {
                     controller: testFeedbackController
                 };
@@ -240,7 +240,7 @@ module.exports = {
                 }
             }
 
-            angular.module('MyMod').directive('testDirective', testDirective);
+            angular.module("MyMod").directive("testDirective", testDirective);
         }
     }
   ]


### PR DESCRIPTION
Adds implicit annotation support for directive definitions
that are returned from a variable.
```javascript
angular.module('MyMod').directive('foo', function() {
  var directive = {
    // Ctrl wasn't annotated before, but will be now.
    controller: function Ctrl(FooService) {},
  };
  return directive;
});
```
Currently, implicit annotations only work for a directive if the
directive definition is returned as an object literal.
```javascript
angular.module('MyMod').directive('foo', function() {
  return {
    // Ctrl is correctly annotated.
    controller: function Ctrl(FooService) {},
  };
});
```
We have used the former quite a lot in our codebase, so we
needed to add support for it. I understand that the general
recommendation for more complex use cases like this is to add
explicit annotations, but here's a PR for the feature anyway
if you are interested. All the tests pass and I added one more
to test this specific case.
