### PR TITLE
Remove ngInject directives from transformed source

### DIFF
--- a/nginject.js
+++ b/nginject.js
@@ -198,6 +198,19 @@ function matchPrologueDirectives(path) {
 
     if(matches.length){
       let match = matches[0].trim();
+
+      // Remove the directive, since it's no longer needed. We skip this for
+      // object methods because we'll recurse back into here after expanding them
+      // into normal functions.
+      if(!t.isObjectMethod(path) || !target.params.length){
+        for(let i=directives.length-1, it; i>=0 ; i--){
+          it = directives[i];
+          if(it.value.value === "ngInject"){
+            directives.splice(i,1);
+          }
+        }
+      }
+
       if(match === "ngInject") return true;
       if(match === "ngNoInject") return false;
     }

--- a/tests/es6.js
+++ b/tests/es6.js
@@ -71,7 +71,6 @@ module.exports = {
     expected: `
       _ngInjectExport.$inject = ['$timeout'];
       export default function _ngInjectExport($timeout) {
-        'ngInject';
         return 'foo';
       }
     `
@@ -138,8 +137,6 @@ module.exports = {
     expected: `
     export default class _ngInjectAnonymousClass {
       constructor($timeout) {
-        'ngInject';
-
         return 'foo';
       }
     }
@@ -184,7 +181,6 @@ module.exports = {
     expected: function(){
       class svc {
           constructor(dep1){
-              'ngInject';
               this.dep1 = dep1;
           }
       }
@@ -204,7 +200,6 @@ module.exports = {
     expected: function() {
       var foo = {
         bar: ['baz', function(baz) {
-          'ngInject';
         }]
       }
     }

--- a/tests/issues.js
+++ b/tests/issues.js
@@ -51,11 +51,9 @@ module.exports = {
 
             __extends(FooBar, _super);
             function FooBar($a, $b) {
-                "ngInject";
                 _super.call(this);
             }
             FooBar.onEnter = ["callback", function (callback) {
-                "ngInject";
                 x;
             }];
             return FooBar;
@@ -196,7 +194,6 @@ module.exports = {
         }]);
       }, expected: function(){
         g(["a", "b", function(a, b) {
-          "ngInject"
         }])
       }
     },
@@ -212,7 +209,6 @@ module.exports = {
       }, expected: function() {
         var outside = function(arg = {}) {
           var inside = function ($q) {
-            'ngInject';
           };
           inside.$inject = ['$q'];
           return inside;
@@ -232,10 +228,8 @@ module.exports = {
       },
       expected: function(){
         module.exports = ['$filterProvider', function($filterProvider) {
-          'ngInject';
           ordinalSuffixFilter.$inject = ['ordinalSuffix'];
           function ordinalSuffixFilter(ordinalSuffix) {
-            'ngInject';
           }
         }];
       },

--- a/tests/ngInject-arrow.js
+++ b/tests/ngInject-arrow.js
@@ -200,7 +200,7 @@ module.exports = {
         var foos3 = ($scope) => {
             // comments are ok before the Directive Prologues
             // and there may be multiple Prologues
-            "use strict"; "ngInject";
+            "use strict";
         };
         foos3.$inject = ["$scope"];
       }
@@ -211,7 +211,7 @@ module.exports = {
         var dual1 = (a) => { "ngInject" }, dual2 = (b) => { "ngInject" };
       },
       expected: function(){
-        var dual1 = (a) => { "ngInject" }, dual2 = (b) => { "ngInject" };
+        var dual1 = (a) => { }, dual2 = (b) => { };
         dual2.$inject = ["b"];
         dual1.$inject = ["a"];
       }
@@ -225,7 +225,6 @@ module.exports = {
       },
       expected: function(){
         g(["c", (c) => {
-            "ngInject"
         }]);
       }
     },

--- a/tests/ngInject.js
+++ b/tests/ngInject.js
@@ -259,7 +259,6 @@ module.exports = {
         Foo2.$inject = ["$scope"];
 
         function Foo2($scope) {
-            "ngInject";
         }
       }
     },
@@ -276,7 +275,7 @@ module.exports = {
         var foos3 = function($scope) {
             // comments are ok before the Directive Prologues
             // and there may be multiple Prologues
-            "use strict"; "ngInject";
+            "use strict";
         };
         foos3.$inject = ["$scope"];
       }
@@ -287,7 +286,7 @@ module.exports = {
         var dual1 = function(a) { "ngInject" }, dual2 = function(b) { "ngInject" };
       },
       expected: function(){
-        var dual1 = function(a) { "ngInject" }, dual2 = function(b) { "ngInject" };
+        var dual1 = function(a) { }, dual2 = function(b) { };
         dual2.$inject = ["b"];
         dual1.$inject = ["a"];
       }
@@ -301,7 +300,6 @@ module.exports = {
       },
       expected: function(){
         g(["c", function(c) {
-            "ngInject"
         }]);
       }
     },


### PR DESCRIPTION
This implements #38 by removing `"ngInject"` prologue directives while we process. In accordance with https://github.com/schmod/babel-plugin-angularjs-annotate/issues/38#issuecomment-357706985, which asks that multiple passes through the transform and minifier still work, I didn't remove `"ngNoInject"` directives, since they are there to prevent the automatic annotation. Multiple runs through minifiers should be OK, since the `$inject` has already been generated and won't be further minified.