### PR TITLE
Check for class expressions in inspectDeclarator

### DIFF
--- a/nginject.js
+++ b/nginject.js
@@ -227,7 +227,7 @@ function inspectAssignment(path, ctx){
 
 function inspectDeclarator(path, ctx){
   const node = path.node;
-  if(!isFunctionExpressionOrArrow(node.init)){
+  if(!isFunctionExpressionOrArrow(node.init) && !t.isClassExpression(node.init)){
     return;
   }
 
@@ -270,10 +270,17 @@ function inspectClassMethod(path, ctx){
   const ancestry = path.getAncestry();
   for(var i=0; i < ancestry.length; i++){
     let ancestor = ancestry[i];
+
     if(ancestor.isClassDeclaration()){
       addSuspect(ancestor, ctx, !annotation);
       return;
     }
+
+	if (ancestor.isClassExpression()) {
+		// Add the variable declaration of the class as suspect
+		addSuspect(ancestor.parentPath.parentPath, ctx, !annotation);
+		return;
+	}
   }
 }
 


### PR DESCRIPTION
Currently `inspectDeclarator` only checks for (arrow)function expressions, but it should also check for class expressions in the form of:
```
/*@ngInject*/
let MyClass = class MyClass { // or as unnamed class
  constructor (myService) {
  }
};
```
and
```
let MyClass = class MyClass { // or as unnamed class

  /*@ngInject*/
  constructor (myService) {
  }
};
```

If you enter the above code in the testpage WITHOUT compiling to ES5 the injection tokens won't be added.