### PR TITLE
support class assigned to var

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -771,7 +771,7 @@ function judgeInjectArraySuspect(path, ctx) {
     path = jumpOverIife(path);
     node = path.node;
 
-    if (t.isClass(node)){
+    if (t.isClass(node) || t.isClassExpression(node)){
         if (!node.id) {
             node.id = path.scope.generateUidIdentifier('ngInjectAnonymousClass');
         }

--- a/nginject.js
+++ b/nginject.js
@@ -274,6 +274,11 @@ function inspectClassMethod(path, ctx){
       addSuspect(ancestor, ctx, !annotation);
       return;
     }
+
+    if (ancestor.isVariableDeclaration()) {
+      addSuspect(ancestor, ctx, !annotation);
+      return;
+    }
   }
 }
 

--- a/tests/es6.js
+++ b/tests/es6.js
@@ -147,6 +147,27 @@ module.exports = {
     `
   },
   {
+    name: "class assigned to a var",
+    explicit: true,
+    noES5: true,
+    input: `
+    let Foo = class Foo {
+      constructor($element) {
+        'ngInject';
+      }
+    };
+  `,
+    expected: `
+    let Foo = class Foo {
+      constructor($element) {
+        'ngInject';
+      }
+    };
+    
+    Foo.$inject = ["$element"];
+  `
+  },
+  {
     name: "annotated constructor",
     explicit: true,
     input: function(){


### PR DESCRIPTION
Support case when class expression assigned to a variable.

```js
let Foo = class Foo {
      constructor($element) {
        'ngInject';
      }
    };
```

Closes https://github.com/schmod/babel-plugin-angularjs-annotate/issues/44

That pattern typically happens in generated code of classes + decorators, when plugin piped after typescript compiler.