### PR TITLE
Use original param name if available

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -899,6 +899,9 @@ function isGenericProviderName(node) {
 function getNamedParam(p) {
   let param = p;
   if (t.isAssignmentPattern(p)) param = p.left;
+  if (param.loc && param.loc.identifierName) {
+      return param.loc.identifierName;
+  }
   return param.name;
 }
 


### PR DESCRIPTION
See #57 for detailed case.

It looks like the original name of function argument can be accessed by `loc` property, so let's do it